### PR TITLE
Jenkins plugin waits for ASE scan to finish even though scan failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <!-- <artifactId>jenkinspider</artifactId> -->
   <artifactId>jenkinsci-appspider-plugin</artifactId>
   <!--<version>1.0</version>-->
-  <version>1.0.10-SNAPSHOT</version>
+  <version>1.0.10</version>
   <packaging>hpi</packaging>
 
   <name>AppSpider Plugin</name>
@@ -78,7 +78,7 @@
     <connection>scm:git:git://github.com/jenkinsci/appspider-build-scanner-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/appspider-build-scanner-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/appspider-build-scanner-plugin.git</url>
-    <tag>jenkinsci-appspider-plugin-1.0.1</tag>
+    <tag>jenkinsci-appspider-plugin-1.0.10</tag>
   </scm>
 
   <!-- Turning off doclint -->

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <!-- <artifactId>jenkinspider</artifactId> -->
   <artifactId>jenkinsci-appspider-plugin</artifactId>
   <!--<version>1.0</version>-->
-  <version>1.0.10</version>
+  <version>1.0.11-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>AppSpider Plugin</name>
@@ -78,7 +78,7 @@
     <connection>scm:git:git://github.com/jenkinsci/appspider-build-scanner-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/appspider-build-scanner-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/appspider-build-scanner-plugin.git</url>
-    <tag>jenkinsci-appspider-plugin-1.0.10</tag>
+    <tag>jenkinsci-appspider-plugin-1.0.1</tag>
   </scm>
 
   <!-- Turning off doclint -->


### PR DESCRIPTION
## Description

plugin was waiting until scan status was either Completed, Stopped, or ReportError before completing, Failed has be added to this list of finishing status'

## Testing
Upgraded dev jenkins server with proposed fix
- ran job known to succeed and verify still succeeds
- ran job and killed the engine mid job forcing a failure and verify the job stops once failure is seen
- usual suite of package unit tests