### PR TITLE
Updated Inconsistent Help Documentation

### DIFF
--- a/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/help-reportName.html
+++ b/src/main/resources/com/rapid7/jenkinspider/PostBuildScan/help-reportName.html
@@ -7,6 +7,6 @@
     <p>
         For example:
         If the report name is named "Sample_test_report", the plugin will name the
-        report generated to "Sample_test_report.[timestamp].xml"
+        report generated to "Sample_test_report_[timestamp].xml"
     </p>
 </div>


### PR DESCRIPTION
Changed . to _ to be consistent with dateTimeStamp in src/main/java/com/rapid7/appspider/Report.java

## Description
This change updates the help message for the Report name field to reflect the actual naming of generated reports. The help message states reports are generated as follows when given "Sample_test_report" as a parameter: "Sample_test_report.[timestamp].xml". However, it actually names the report as  "Sample_test_report_[timestamp].xml"

## Testing
Rebuilt plugin and deployed to a local Jenkins instance to verify help message was updated and correct. 
